### PR TITLE
Add property description to `Popup`

### DIFF
--- a/doc/classes/Popup.xml
+++ b/doc/classes/Popup.xml
@@ -13,6 +13,7 @@
 	<members>
 		<member name="borderless" type="bool" setter="set_flag" getter="get_flag" override="true" default="true" />
 		<member name="close_on_parent_focus" type="bool" setter="set_close_on_parent_focus" getter="get_close_on_parent_focus" default="true">
+			If [code]true[/code], the [Popup] will close when its parent is focused.
 		</member>
 		<member name="transient" type="bool" setter="set_transient" getter="is_transient" override="true" default="true" />
 		<member name="unresizable" type="bool" setter="set_flag" getter="get_flag" override="true" default="true" />


### PR DESCRIPTION
This pull request adds a missing property description to `Popup` in the class docs.