### PR TITLE
Add method description to `Tree`

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -270,6 +270,7 @@
 			<argument index="0" name="item" type="Object">
 			</argument>
 			<description>
+				Causes the [Tree] to jump to the specified item.
 			</description>
 		</method>
 		<method name="set_column_custom_minimum_width">


### PR DESCRIPTION
This pull request adds a missing method to `Tree` in the class docs.